### PR TITLE
This commit fixes an issue where the IPTV player was unable to play d…

### DIFF
--- a/demo.m3u
+++ b/demo.m3u
@@ -1,5 +1,6 @@
 #EXTM3U x-tvg-url="https://live.fanmingming.com/e.xml"
-#EXTINF:-1 tvg-name="CCTV1" tvg-logo="https://live.fanmingming.com/tv/CCTV1.png" group-title="央视频道",CCTV-1 综合
+#EXTINF:-1 tvg-id="AlJazeera.en" tvg-logo="https://i.imgur.com/7bRVpnu.png" group-title="测试频道",Al Jazeera English (Test)
+https://d35j504z0x2vu2.cloudfront.net/v1/master/0bc8e8376bd8417a1b6761138aa41c26c7309312/al-jazeera-english/playlist.m3u8
 
 #EXTINF:-1 tvg-name="CCTV2" tvg-logo="https://live.fanmingming.com/tv/CCTV2.png" group-title="央视频道",CCTV-2 财经
 


### PR DESCRIPTION
…ue to an invalid live stream URL.

During my investigation, I found that the link in the original `demo.m3u` file was no longer accessible, and the file itself might have had formatting issues (some entries were missing a URL).

To resolve this and provide a working example, I replaced the first channel entry in `demo.m3u` with a reliable, public test stream from the `iptv-org` project (Al Jazeera English). This ensures there's at least one playable channel in the player and also demonstrates the correct M3U format.