### PR TITLE
This commit fixes an issue where the previously selected test live so…

### DIFF
--- a/demo.m3u
+++ b/demo.m3u
@@ -1,6 +1,6 @@
 #EXTM3U x-tvg-url="https://live.fanmingming.com/e.xml"
-#EXTINF:-1 tvg-id="AlJazeera.en" tvg-logo="https://i.imgur.com/7bRVpnu.png" group-title="测试频道",Al Jazeera English (Test)
-https://d35j504z0x2vu2.cloudfront.net/v1/master/0bc8e8376bd8417a1b6761138aa41c26c7309312/al-jazeera-english/playlist.m3u8
+#EXTINF:-1 tvg-id="DW.de@English" tvg-logo="https://i.imgur.com/8MRNFb9.png" group-title="测试频道",DW English (Test)
+https://dwamdstream102.akamaized.net/hls/live/2015525/dwstream102/index.m3u8
 
 #EXTINF:-1 tvg-name="CCTV2" tvg-logo="https://live.fanmingming.com/tv/CCTV2.png" group-title="央视频道",CCTV-2 财经
 


### PR DESCRIPTION
…urce (Al Jazeera) was returning a 504 Gateway Timeout error.

I have replaced the Al Jazeera live stream with a new public test stream from Deutsche Welle (DW English), which generally has better stability. This iterative process also demonstrates the instability of public IPTV sources.

This fix provides you with a currently available playback example.