### PR TITLE
This commit fixes an image display issue on the homepage.

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
             </div>
             <div class="col">
                 <div class="card shadow-sm">
-                    <img src="https://images.unsplash.com/photo-1550745165-9bc0b252726a?q=80&w=2070" class="card-img-top" alt="Technology">
+                    <img src="https://images.unsplash.com/photo-1518770660439-4636190af475" class="card-img-top" alt="Technology">
                     <div class="card-body"><p class="card-text text-center">科技之光</p></div>
                 </div>
             </div>


### PR DESCRIPTION
The image in the "Light of Technology" card was not displaying because the original Unsplash link was broken or had expired. This link has now been replaced with a new, valid, and thematically relevant image link.